### PR TITLE
setting ue_pythonpaths from pythonpaths in env to get it out of slate

### DIFF
--- a/client/ayon_unreal/addon.py
+++ b/client/ayon_unreal/addon.py
@@ -14,6 +14,8 @@ class UnrealAddon(AYONAddon, IHostAddon):
 
     def initialize(self, settings):
         self.enabled = settings[self.name]['enabled']
+        if 'UE_PYTHONPATH' not in os.environ:
+            os.environ['UE_PYTHONPATH'] = os.environ['PYTHONPATH']
         return super().initialize(settings)
 
     def get_global_environments(self):


### PR DESCRIPTION
Putting this loading of PYTHONPATHs into UE_PYTHONPATH into the init for Unreal