### PR TITLE
ENG-4243: Unreal Engine fails to launch from AYON with RuntimeError: Invalid Project Path

### DIFF
--- a/client/ayon_unreal/hooks/pre_workfile_preparation.py
+++ b/client/ayon_unreal/hooks/pre_workfile_preparation.py
@@ -301,6 +301,18 @@ class UnrealPrelaunchHook(PreLaunchHook):
             project_file = pathlib.Path(project_template.format_strict(template_data))
             project_path = project_file.parent
             self.log.info(f"Using exact path: {project_file}")
+            if not project_file.is_file():
+                raise ApplicationLaunchFailed(
+                    f"{self.signature} 'Use exact path' is enabled but the "
+                    f"resolved Unreal project file does not exist:\n\n"
+                    f"    {project_file.as_posix()}\n\n"
+                    f"Resolved from anatomy template: "
+                    f"'{project_template_str}'\n\n"
+                    "Please verify that the 'Existing uproject directory' "
+                    "template and the project anatomy roots are configured "
+                    "correctly, and that the .uproject file exists at the "
+                    "resolved path."
+                )
         else:
             project_file = project_path / unreal_project_filename
 
@@ -310,7 +322,7 @@ class UnrealPrelaunchHook(PreLaunchHook):
         if import_storage_path:
             self.launch_context.env["AYON_UNREAL_IMPORT_PATH"] = import_storage_path
 
-        if not project_file.is_file():
+        if not use_exact_path and not project_file.is_file():
 
             # Get project settings -> allow project creation
             current_project = self.launch_context.data['project_entity']['name']


### PR DESCRIPTION
## Summary

Reported via Snooker Slack bot. Unreal Engine fails to launch from AYON,
throwing `RuntimeError: Invalid Project Path` during the pre-workfile
preparation hook.

```
Raised in: .../ayon_unreal/hooks/pre_workfile_preparation.py at line 283
Stack: addon.py:281 -> manager.py:193/169/707/690 -> pre_workfile_preparation.py:283
```

Addon version involved: `unreal_0.2.13+halon.6` (applications addon 1.3.0).

Unreal Engine fails to launch from AYON with RuntimeError: Invalid Project Path

---

## Approach

The bug originates from the `use_exact_path=True` code path in `pre_workfile_preparation.py`. In version `0.2.13+halon.6`, when the resolved `.uproject` file didn't exist at the formatted path, the code raised `RuntimeError("Invalid Project Path")` — an unhelpful, generic error that gave no diagnostic information.

In the current dev code (`0.2.15`), that `RuntimeError` was removed entirely during the refactor in commit `40812e6`. However, the removal was too permissive: when `use_exact_path=True` and the resolved project file doesn't exist, execution now falls through to the generic `if not project_file.is_file():` block at line 313. That block then re-reads `existing_uproject_directory` **as a raw directory path** (not as an anatomy template), which will silently produce the wrong behavior or crash unexpectedly when `allow_project_creation=True`.

The fix is to add a `ApplicationLaunchFailed` guard **inside the `if use_exact_path:` block**, immediately after line 303, so that a missing file produces a clear, actionable error message pointing to the anatomy template and root configuration — rather than either a cryptic `RuntimeError` or silently falling into project-creation logic that makes no sense for the `use_exact_path` intent.

---

## Changes

- `client/ayon_unreal/hooks/pre_workfile_preparation.py`

---

## Related Ticket(s)

[ENG-4243](https://halon.atlassian.net/browse/ENG-4243)

---

## Testing

1. In AYON studio settings for a test project:
   - Set `unreal/project_setup/use_exact_path` to `True`.
   - Set `unreal/project_setup/existing_uproject_directory` to an
     anatomy template that resolves to a path where **no** `.uproject`
     exists (for example, point `root` at a scratch folder).
2. Launch Unreal for a task in that project.
3. Verify the launch fails with `ApplicationLaunchFailed` and a message
   that includes the resolved path and a reference to the anatomy
   template — **not** a bare `RuntimeError: Invalid Project Path`, and
   **not** an `allow_project_creation`-driven side effect.
4. Place a valid `.uproject` at the resolved location and relaunch.
   Unreal should launch normally and `AYON_UNREAL_PROJECT_PATH` should
   be set to the parent directory.
5. Regression: with `use_exact_path=False` and
   `allow_project_creation=True`, confirm that launching into a task
   without an existing project still triggers the generation /
   copy-from-template flow exactly as before.

---

## Additional Context

- `format_strict` can still raise `TemplateUnsolvableError` if the
  anatomy template references keys that `get_template_data` does not
  populate. That is a separate failure mode and is intentionally left
  to propagate; fixing the `use_exact_path` missing-file error was the
  scope of this ticket.
- If both `use_exact_path=True` and `allow_project_creation=True` are
  configured simultaneously (nonsensical combination), this change now
  explicitly prefers the `use_exact_path` semantics and will not
  attempt project creation.
- Compiled clean with `python -m py_compile`.

---

*Autonomous agent implementation — reviewed and approved by human.*

[ENG-4243]: https://halon.atlassian.net/browse/ENG-4243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ