### PR TITLE
ENG-4281: AYON camera import to Unreal Engine crashes with Invalid USkeleton error

### DIFF
--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -228,9 +228,12 @@ class CameraLoader(plugin.Loader):
         EditorLevelLibrary.save_all_dirty_levels()
         EditorLevelLibrary.load_level(master_level)
 
-        # Save all assets in the hierarchy
+        # Save only assets in the camera's own directory, not the entire
+        # hierarchy. Other products (e.g. animation rigs) may live under the
+        # same hierarchy_dir and saving them can trigger unrelated validation
+        # errors such as "Invalid USkeleton".
         asset_content = EditorAssetLibrary.list_assets(
-            hierarchy_dir, recursive=True, include_folder=False
+            asset_dir, recursive=True, include_folder=False
         )
 
         for a in asset_content:
@@ -283,9 +286,9 @@ class CameraLoader(plugin.Loader):
         EditorLevelLibrary.save_all_dirty_levels()
         EditorLevelLibrary.load_level(master_level)
 
-        # Save all assets in the hierarchy
+        # Save only camera assets — see load() comment for rationale.
         asset_content = EditorAssetLibrary.list_assets(
-            hierarchy_dir, recursive=True, include_folder=False
+            asset_dir, recursive=True, include_folder=False
         )
 
         for a in asset_content:


### PR DESCRIPTION
## Summary

Importing a camera to Unreal Engine via AYON using the camera FBX option crashes UE.
The error references character rig paths and skeleton assets (`Invalid USkeleton`),
even though only a camera asset is being imported.

The crash originates from `load_camera.py` line 237 where `EditorAssetLibrary.save_asset(a)`
is called on assets from the shared hierarchy directory, which includes unrelated animation
rig assets with skeleton dependencies.

The camera loader's `load()` and `update()` methods used `hierarchy_dir` (the shared
top-level folder like `/Game/Ayon/content/01_previs/zzz/`) when listing assets to save.
This picked up assets from OTHER products (animation rigs, skeletal meshes) that happened
to live under the same hierarchy. Saving those unrelated assets triggered UE's skeleton
validation, causing the "Invalid USkeleton" crash.

**Fix**: Changed both methods to use `asset_dir` (the camera's own subdirectory) instead
of `hierarchy_dir`, so only camera-related assets are saved.

---

## Changes

- `client/ayon_unreal/plugins/load/load_camera.py` — changed `list_assets()` scope from `hierarchy_dir` to `asset_dir` in both `load()` and `update()` methods

---

## Related Ticket(s)

[ENG-4281](https://halon.atlassian.net/browse/ENG-4281)

---

## Testing

1. In an AYON project with existing animation rig assets loaded in UE
2. Load a camera product using the FBX representation via AYON loader
3. Verify the camera loads without crashing
4. Update the camera container and verify no crash on update either
5. Confirm other assets in the hierarchy are unaffected

---

## Additional Context

- **Confidence**: high — the fix is minimal and directly addresses the root cause (saving unrelated assets). The `asset_dir` variable is already computed and used elsewhere in both methods.
- Syntax validation: pass (py_compile)
- Self-QA via Windows MCP: skipped (Unreal Engine plugin, not Maya/DCC)

---

*Autonomous agent implementation — reviewed and approved by human.*

[ENG-4281]: https://halon.atlassian.net/browse/ENG-4281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ