### PR TITLE
ENG-4471: Fix layout loader crash and slow processing

### DIFF
--- a/client/ayon_unreal/api/plugin.py
+++ b/client/ayon_unreal/api/plugin.py
@@ -426,8 +426,10 @@ class LayoutLoader(Loader):
         imprint(
             "{}/{}".format(asset_dir, container_name), data)
 
-    def _load_assets(self, instance_name, repre_id, product_type, repr_format):
-        all_loaders = discover_loader_plugins()
+    def _load_assets(self, instance_name, repre_id, product_type, repr_format,
+                     all_loaders=None):
+        if all_loaders is None:
+            all_loaders = discover_loader_plugins()
         loaders = loaders_from_representation(
             all_loaders, repre_id)
 
@@ -450,7 +452,7 @@ class LayoutLoader(Loader):
                     f"No valid loader found for {repre_id} "
                     f"({repr_format}) "
                     f"{product_type}")
-            return
+            return []
 
         import_options = {
             "layout": True
@@ -461,7 +463,7 @@ class LayoutLoader(Loader):
             namespace=instance_name,
             options=import_options
         )
-        return assets
+        return assets or []
 
     def _remove_Loaded_asset(self, container):
         """

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Loader for layouts."""
+import collections
 import json
 from pathlib import Path
 import unreal
@@ -10,7 +11,10 @@ from unreal import (
 )
 import ayon_api
 
-from ayon_core.pipeline import get_current_project_name
+from ayon_core.pipeline import (
+    get_current_project_name,
+    discover_loader_plugins,
+)
 from ayon_core.settings import get_current_project_settings
 from ayon_unreal.api import plugin
 from ayon_unreal.api.pipeline import (
@@ -127,7 +131,6 @@ class LayoutLoader(plugin.LayoutLoader):
         with open(lib_path, "r") as fp:
             data = json.load(fp)
 
-
         if not repr_loaded:
             repr_loaded = []
 
@@ -138,6 +141,16 @@ class LayoutLoader(plugin.LayoutLoader):
         bindings_dict = {}
 
         loaded_assets = []
+
+        # Discover loader plugins once for all elements instead of per-element
+        all_loaders = discover_loader_plugins()
+
+        # Pre-group elements by version_id to avoid O(n²) inner scan
+        instances_by_version = collections.defaultdict(list)
+        for item in data:
+            version_id = item.get('version')
+            if version_id:
+                instances_by_version[version_id].append(item)
 
         repre_entities_by_version_id = self._get_repre_entities_by_version_id(
             project_name, data, loaded_extension, force_loaded=force_loaded
@@ -185,7 +198,8 @@ class LayoutLoader(plugin.LayoutLoader):
                     product_type = element.get("family")
 
                 assets = self._load_assets(
-                    instance_name, repre_id, product_type, repr_format
+                    instance_name, repre_id, product_type, repr_format,
+                    all_loaders=all_loaders
                 )
 
                 container = None
@@ -199,11 +213,9 @@ class LayoutLoader(plugin.LayoutLoader):
                     if container is not None:
                         loaded_assets.append(container.get_path_name())
 
-                instances = [
-                    item for item in data
-                    if ((item.get('version') and
-                        item.get('version') == element.get('version'))
-                        )]
+                # Use pre-grouped lookup instead of scanning all elements
+                instances = instances_by_version.get(
+                    element.get('version'), [])
 
                 for instance in instances:
                     transform = instance.get('transform_matrix')

--- a/client/ayon_unreal/plugins/load/load_layout_existing.py
+++ b/client/ayon_unreal/plugins/load/load_layout_existing.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import unreal
 from unreal import EditorLevelLibrary
 import ayon_api
+from ayon_core.pipeline import discover_loader_plugins
 from ayon_core.pipeline.load import LoadError
 from ayon_unreal.api import plugin
 from ayon_unreal.api import pipeline as upipeline
@@ -59,7 +60,8 @@ class ExistingLayoutLoader(plugin.LayoutLoader):
                 "Skipping to add spawned actor into the sequence."
             )
 
-    def _load_asset(self, repr_data, instance_name, family, extension):
+    def _load_asset(self, repr_data, instance_name, family, extension,
+                    all_loaders=None):
         repre_entity = next((repre_entity for repre_entity in repr_data
                              if repre_entity["name"] == extension), None)
         if not repre_entity or extension == "ma":
@@ -68,7 +70,8 @@ class ExistingLayoutLoader(plugin.LayoutLoader):
         repr_format = repre_entity.get('name')
         representation = repre_entity.get('id')
         assets = self._load_assets(
-            instance_name, representation, family, repr_format
+            instance_name, representation, family, repr_format,
+            all_loaders=all_loaders
         )
         return assets
 
@@ -123,6 +126,8 @@ class ExistingLayoutLoader(plugin.LayoutLoader):
         repre_entities_by_version_id = self._get_repre_entities_by_version_id(
             project_name, data, "json"
         )
+        # Discover loader plugins once for all elements
+        all_loaders = discover_loader_plugins()
         containers = []
         actors_matched = []
 
@@ -231,7 +236,8 @@ class ExistingLayoutLoader(plugin.LayoutLoader):
                 repre_entities,
                 lasset.get('instance_name'),
                 product_type,
-                extension
+                extension,
+                all_loaders=all_loaders
             )
             con = None
             for asset in assets:


### PR DESCRIPTION
## Summary

- **Fix crash**: `_load_assets()` returned `None` when no valid loader was found (e.g., `.ma` representations with no FBX/ABC fallback). Callers iterated the result directly, causing `TypeError: 'NoneType' object is not iterable`. Now returns `[]`.
- **Fix slow processing**: `discover_loader_plugins()` was called per layout element (filesystem scan each time). Now cached once per load operation. Also replaced O(n²) version-matching list comprehension with O(n) dict lookup.
- Applied same caching pattern to `ExistingLayoutLoader` for consistency.

## Test plan

- [ ] Load a layout in Unreal containing elements with `.ma`-only representations — should skip gracefully with warning instead of crashing
- [ ] Load a large layout (many elements) — should be noticeably faster than before
- [ ] Verify normal layout loading (FBX/ABC assets) still works correctly
- [ ] Verify "Load Layout on Existing Scene" loader still works

Jira: https://halon.atlassian.net/browse/ENG-4471

🤖 Generated with [Claude Code](https://claude.com/claude-code)