### PR TITLE
ENG-4677: Fix KeyError 'parent' in Maya→Unreal rig animation loader

### DIFF
--- a/client/ayon_unreal/plugins/inventory/update_container_path.py
+++ b/client/ayon_unreal/plugins/inventory/update_container_path.py
@@ -60,7 +60,17 @@ class UpdateContainerPath(InventoryAction):
             if target_container_dir:
                 target_container_dir = unreal.Paths.get_path(target_container_dir)
                 container_name = container.get("container_name")
-                data = {"namespace": target_container_dir}
+                # Carry the container identity forward. This re-imprints the
+                # container at its new content-plugin path; imprinting only
+                # "namespace" left the migrated container without a "parent"
+                # (and other identity) tag, which later crashed consumers of
+                # ls() with KeyError: 'parent' (ENG-4677).
+                data = {
+                    "namespace": target_container_dir,
+                    "parent": container.get("parent"),
+                    "representation": container.get("representation"),
+                    "loader": container.get("loader"),
+                }
                 imprint(f"{target_container_dir}/{container_name}", data)
 
                 asset_content = unreal.EditorAssetLibrary.list_assets(

--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -272,10 +272,15 @@ class AnimationFBXLoader(plugin.Loader):
         containers = unreal_pipeline.ls()
         for container in containers:
             self.log.debug(f"Checking container: {container}")
-            if container["parent"] in rigs:
-                unreal.log("{}".format(container["parent"]))
+            # Containers in the scene may have been imprinted by different
+            # loaders/schemas and are not guaranteed to carry a "parent" tag.
+            # Use .get() so a container without it is skipped instead of
+            # raising KeyError and aborting the whole rig -> animation load.
+            parent = container.get("parent")
+            if parent and parent in rigs:
+                unreal.log("{}".format(parent))
                 # we found loaded version of the linked rigs
-                if container["loader"] != "SkeletalMeshFBXLoader":
+                if container.get("loader") != "SkeletalMeshFBXLoader":
                     continue
                 namespace = container["namespace"]
 


### PR DESCRIPTION
## Problem
Importing rigs from Maya into Unreal crashes with `KeyError: 'parent'`, causing a work stoppage for multiple artists. Reproduced loading `animationrig_combatdrone_rigMain_002` (fbx, v7).

Jira: https://halon.atlassian.net/browse/ENG-4677

## Root cause (two parts)
`unreal_pipeline.ls()` yields metadata for every `AyonAssetContainer` in the scene, and consumers read `container["parent"]`. Two issues combined to cause the crash:

1. **The producer** — `plugins/inventory/update_container_path.py` (`UpdateContainerPath` action) migrates a container to the content plugin and re-imprints **only `"namespace"`**, dropping the `"parent"` (and `representation`/`loader`) identity tags. It writes to the content-plugin asset path — a *different* node from the source `/Game` container — so the migrated container ends up without a `parent` tag. This is what manufactures the malformed containers.
2. **The consumer** — `plugins/load/load_animation.py` `_load_standalone_animation` iterates over **every** container searching for a linked rig and indexed `container["parent"]` directly. The first parent-less container raises `KeyError: 'parent'` and aborts the whole rig→animation load, even though that container is irrelevant to the rig.

The two meet in the content-plugin flow: `load_animation`'s `_get_content_plugin_filter` path is specifically about content-plugin assets, which is exactly where `UpdateContainerPath` leaves parent-less containers.

## Fix
- `update_container_path.py`: carry `parent`/`representation`/`loader` forward so migrated containers stay complete `AyonAssetContainer`s (fixes the source of the bad data).
- `load_animation.py`: use `container.get("parent")`/`.get("loader")` and skip non-matching containers instead of crashing — defensive read matching the existing pattern in `connect_animation_to_sequence.py`, and protection against any pre-existing malformed containers already in artists' scenes.

## Imprint audit
Checked every container-creation path across all loaders (`plugins/load/*`), `api/plugin.py`, and inventory actions. All loader `load()`/`update()`/`switch()` paths correctly imprint `parent`. `containerise()` in `api/pipeline.py` omits `parent` but is **dead code** (never invoked in this addon — docstring mentions only). The only live path that dropped `parent` was `update_container_path.py`, now fixed.

## Verification
- `python -m py_compile` on both files → OK.
- Isolated logic reproduction of the loader loop: original subscript raises `KeyError: 'parent'`; patched `.get()` runs clean **and still finds the matching rig container**.
- In-engine verification via the Crucible Windows/Unreal test context (load the affected product, and exercise the Update Container Path action) — see ticket REVIEW.md.

## Notes
- Behavior-preserving on the read side: only skips containers that previously crashed the loop; matching rigs are discovered identically.
- No automated unit test added — both methods are hard-coupled to the live `unreal` module and cannot be imported outside an Unreal session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)